### PR TITLE
added remote-add

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ To install, use `ninja install`, then execute with `com.github.muriloventuroso.e
 ## Install with Flatpak
 
 Install:
-
+    
+    flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
     flatpak install flathub com.github.muriloventuroso.easyssh
 
 Run:


### PR DESCRIPTION
When not on elementary remote-add flathub might be necessary before install. Even if it already exists, it does not matter due to the --if-not-exists option