### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,14 @@ asresources = gnome.compile_resources(
     c_name: 'as'
 )
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src' / 'Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
 
 dependencies = [
     dependency('gee-0.8'),
@@ -31,18 +39,15 @@ dependencies = [
     meson.get_compiler('c').find_library('m', required : false)
 ]
 
-
 if with_gpg
     gpg = find_program('gpg', 'gpg2', required: true)
     add_project_arguments(['--define', 'WITH_GPG'], language : 'vala')
-
 endif
-
-
 
 executable(
     meson.project_name(),
     asresources,
+    config_file,
     'src/Application.vala',
     'src/Host.vala',
     'src/Account.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,6 +31,9 @@ namespace EasySSH {
 
         construct {
             Intl.setlocale (LocaleCategory.ALL, "");
+            Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+            Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+            Intl.textdomain (GETTEXT_PACKAGE);
         }
 
         protected override void activate () {

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
This fixes the translations not being loaded in Flatpak version of the app:

![Screenshot from 2021-11-16 09-56-37](https://user-images.githubusercontent.com/26003928/141877105-06174f78-2d7f-4f5b-93d0-a8935593ebc8.png)
