### PR TITLE
Preferences: Rewrite using Granite.Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you want to hack on and build EasySSH yourself, you'll need the following dep
 
 * libgee-0.8-dev
 * libgtk-3-dev
-* libgranite-dev
+* libgranite-dev (>= 6.0.0)
 * libvte-2.91-dev
 * libjson-glib-dev
 * meson

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ dependencies = [
     dependency('gee-0.8'),
     dependency('glib-2.0'),
     dependency('gtk+-3.0'),
-    dependency('granite'),
+    dependency('granite', version: '>=6.0.0'),
     dependency('json-glib-1.0'),
     dependency('vte-2.91', version: '>0.52'),
     dependency('gee-0.8'),

--- a/src/Widgets/Preferences.vala
+++ b/src/Widgets/Preferences.vala
@@ -21,28 +21,32 @@
 
 
 namespace EasySSH {
-    public class Preferences : Gtk.Dialog {
-        private Gtk.Stack main_stack;
+    public class Preferences : Granite.Dialog {
+        private Settings settings;
 
-        Settings settings;
-
-
-        public Preferences (Gtk.Window? parent) {
+        public Preferences (Gtk.Window parent) {
             Object (
-                border_width: 5,
-                deletable: false,
-                resizable: false,
+                border_width: 6,
                 title: _("Preferences"),
                 transient_for: parent
             );
-
         }
 
         construct {
+            var infobar = new Gtk.InfoBar () {
+                message_type = Gtk.MessageType.INFO,
+                margin_bottom = 12
+            };
             var restart_label = new Gtk.Label(_("Restart to apply changes"));
+            infobar.get_content_area ().add (restart_label);
+            infobar.add_button (_("Quit App"), Gtk.ResponseType.ACCEPT);
+            infobar.response.connect ((response_id) => {
+                ((GLib.Application) GLib.Application.get_default ()).activate_action ("quit", null);
+            });
+
             var restart_revealer = new Gtk.Revealer ();
-            restart_revealer.set_transition_type (Gtk.RevealerTransitionType.CROSSFADE);
-            restart_revealer.add (restart_label);
+            restart_revealer.set_transition_type (Gtk.RevealerTransitionType.SLIDE_DOWN);
+            restart_revealer.add (infobar);
             restart_revealer.set_reveal_child (false);
             settings = Settings.get_default ();
             var hosts_filechooser = new Gtk.FileChooserButton (_("Select Hosts Configuration Folder…"), Gtk.FileChooserAction.SELECT_FOLDER);
@@ -82,6 +86,7 @@ namespace EasySSH {
             });
             var scrollback_help = new Gtk.Label(_("0 to disable. -1 to unlimited"));
             scrollback_help.halign = Gtk.Align.START;
+            scrollback_help.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
             var sync_ssh_switch = new Gtk.Switch();
             sync_ssh_switch.halign = Gtk.Align.START;
@@ -115,46 +120,83 @@ namespace EasySSH {
             use_dark_theme.active = settings.use_dark_theme;
             use_dark_theme.notify["active"].connect (() => { settings.use_dark_theme = use_dark_theme.active; });
 
+            var hosts_label = new Gtk.Label (_("Hosts Configuration Folder:")) {
+                halign = Gtk.Align.END
+            };
+
+            var scrollback_label = new Gtk.Label (_("Scrollback lines:")) {
+                halign = Gtk.Align.END
+            };
+
+            var restore_hosts_label = new Gtk.Label (_("Restore Opened Hosts:")) {
+                halign = Gtk.Align.END
+            };
+
+            var sync_ssh_label = new Gtk.Label (_("Sync SSH Config:")) {
+                halign = Gtk.Align.END
+            };
+
+            var audible_bell_label = new Gtk.Label (_("Audible Bell:")) {
+                halign = Gtk.Align.END
+            };
+
             var general_grid = new Gtk.Grid ();
             general_grid.column_spacing = 12;
             general_grid.row_spacing = 6;
-            general_grid.attach (new Granite.HeaderLabel (_("Hosts Configuration Folder:")), 0, 0, 1, 1);
+
+            general_grid.attach (hosts_label, 0, 0, 1, 1);
             general_grid.attach (hosts_filechooser, 1, 0, 1, 1);
 
-            general_grid.attach (new Granite.HeaderLabel (_("Scrollback lines:")), 0, 1, 1, 1);
+            general_grid.attach (scrollback_label, 0, 1, 1, 1);
             general_grid.attach (scrollback_lines_input, 1, 1, 1, 1);
             general_grid.attach (scrollback_help, 1, 2, 1, 1);
 
-            general_grid.attach (new Granite.HeaderLabel (_("Restore Opened Hosts:")), 0, 3, 1, 1);
+            general_grid.attach (restore_hosts_label, 0, 3, 1, 1);
             general_grid.attach (restore_hosts_switch, 1, 3, 1, 1);
 
-            general_grid.attach (new Granite.HeaderLabel (_("Sync SSH Config:")), 0, 4, 1, 1);
+            general_grid.attach (sync_ssh_label, 0, 4, 1, 1);
             general_grid.attach (sync_ssh_switch, 1, 4, 1, 1);
 
-            general_grid.attach (new Granite.HeaderLabel (_("Audible Bell:")), 0, 5, 1, 1);
+            general_grid.attach (audible_bell_label, 0, 5, 1, 1);
             general_grid.attach (audible_bell_switch, 1, 5, 1, 1);
 
             #if WITH_GPG
-            general_grid.attach (new Granite.HeaderLabel (_("Encrypt data:")), 0, 6, 1, 1);
+            var enctypt_data_label = new Gtk.Label (_("Encrypt data:")) {
+                halign = Gtk.Align.END
+            };
+
+            general_grid.attach (enctypt_data_label, 0, 6, 1, 1);
             general_grid.attach (encrypt_data_switch, 1, 6, 1, 1);
             #endif
 
 
-            var appearance_grid = new Gtk.Grid ();
+            var terminal_background_color_label = new Gtk.Label (_("Terminal Background Color:")) {
+                halign = Gtk.Align.END
+            };
 
-            appearance_grid.attach (new Granite.HeaderLabel (_("Terminal Background Color:")), 0, 0, 1, 1);
+            var terminal_font_label = new Gtk.Label (_("Terminal Font:")) {
+                halign = Gtk.Align.END
+            };
+
+            var use_dark_theme_label = new Gtk.Label (_("Use Dark Theme:")) {
+                halign = Gtk.Align.END
+            };
+
+            var appearance_grid = new Gtk.Grid ();
+            appearance_grid.column_spacing = 12;
+            appearance_grid.row_spacing = 6;
+
+            appearance_grid.attach (terminal_background_color_label, 0, 0, 1, 1);
             appearance_grid.attach (terminal_background_color_button, 1, 0, 1, 1);
 
-            appearance_grid.attach (new Granite.HeaderLabel (_("Terminal Font:")), 0, 1, 1, 1);
+            appearance_grid.attach (terminal_font_label, 0, 1, 1, 1);
             appearance_grid.attach (terminal_font_button, 1, 1, 1, 1);
 
-            appearance_grid.attach (new Granite.HeaderLabel (_("Use Dark Theme:")), 0, 2, 1, 1);
+            appearance_grid.attach (use_dark_theme_label, 0, 2, 1, 1);
             appearance_grid.attach (use_dark_theme, 1, 2, 1, 1);
 
-            main_stack = new Gtk.Stack ();
-            main_stack.margin = 6;
-            main_stack.margin_bottom = 18;
-            main_stack.margin_top = 24;
+            var main_stack = new Gtk.Stack ();
+            main_stack.margin = 12;
             main_stack.add_titled (general_grid, "general", _("General"));
             main_stack.add_titled (appearance_grid, "appearance", _("Appearance"));
 
@@ -163,10 +205,9 @@ namespace EasySSH {
             main_stackswitcher.halign = Gtk.Align.CENTER;
 
             var main_grid = new Gtk.Grid ();
-            main_grid.attach (main_stackswitcher, 0, 0, 1, 1);
-            main_grid.attach (main_stack, 0, 1, 1, 1);
-            
-            main_grid.attach (restart_revealer, 0, 2, 1, 1);
+            main_grid.attach (restart_revealer, 0, 0, 1, 1);
+            main_grid.attach (main_stackswitcher, 0, 1, 1, 1);
+            main_grid.attach (main_stack, 0, 2, 1, 1);
 
             get_content_area ().add (main_grid);
 


### PR DESCRIPTION
Make the Preference dialog look more native and consistence with elementary OS desktop.

## Before
![Screenshot from 2021-11-16 21-54-14](https://user-images.githubusercontent.com/26003928/141988898-b516738b-9128-423a-9320-36b2db6e0b23.png)
![Screenshot from 2021-11-16 21-54-17](https://user-images.githubusercontent.com/26003928/141988900-c35ced82-9518-4d03-be83-8f336ef10f9f.png)
![Screenshot from 2021-11-16 21-54-21](https://user-images.githubusercontent.com/26003928/141988904-c3d192a3-7236-461a-8dbe-c5ab28f95183.png)

## After
![Screenshot from 2021-11-16 21-50-52](https://user-images.githubusercontent.com/26003928/141988928-eb111e4f-bc5f-4eab-b3ad-54fd0f5c38cf.png)
![Screenshot from 2021-11-16 21-50-54](https://user-images.githubusercontent.com/26003928/141988932-0ff4b55e-68a9-460f-b5f9-a4c3ea8d4dd6.png)
![Screenshot from 2021-11-16 21-51-00](https://user-images.githubusercontent.com/26003928/141988935-15d87236-3383-451b-aaff-44d83c53d71f.png)
