### PR TITLE
Update modules

### DIFF
--- a/com.github.muriloventuroso.easyssh.yml
+++ b/com.github.muriloventuroso.easyssh.yml
@@ -1,6 +1,6 @@
 app-id: com.github.muriloventuroso.easyssh
 runtime: io.elementary.Platform
-runtime-version: '6'
+runtime-version: '6.1'
 sdk: io.elementary.Sdk
 command: com.github.muriloventuroso.easyssh
 finish-args:

--- a/com.github.muriloventuroso.easyssh.yml
+++ b/com.github.muriloventuroso.easyssh.yml
@@ -19,8 +19,8 @@ modules:
     - '-Ddocs=false'
     sources:
     - type: archive
-      url: https://download.gnome.org/sources/vte/0.66/vte-0.66.0.tar.xz
-      sha256: d0813ac00fb1d74d88851e765f755d496c83e097097358ea1baadb38b37b7b33
+      url: https://download.gnome.org/sources/vte/0.66/vte-0.66.2.tar.xz
+      sha256: e89974673a72a0a06edac6d17830b82bb124decf0cb3b52cebc92ec3ff04d976
   - name: easyssh
     buildsystem: meson
     config-opts:

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('com.github.muriloventuroso.easyssh', 'vala', 'c', version: '1.7.0')
+project('com.github.muriloventuroso.easyssh', 'vala', 'c', version: '1.7.8')
 
 gnome = import('gnome')
 i18n = import('i18n')


### PR DESCRIPTION
- Flatpak: Update vte to 0.66.2
- Flatpak: Update elementary Flatpak modules to 6.1 (6 is now considered as EOL)
- meson: Fix app version (which actually should be updated every time before publishing a new release)
