### PR TITLE
Set option values for recent version of vte

### DIFF
--- a/com.github.muriloventuroso.easyssh.yml
+++ b/com.github.muriloventuroso.easyssh.yml
@@ -23,9 +23,6 @@ modules:
       sha256: e89974673a72a0a06edac6d17830b82bb124decf0cb3b52cebc92ec3ff04d976
   - name: easyssh
     buildsystem: meson
-    config-opts:
-    - '-Dubuntu-bionic-patched-vte=false'
-    - '-Dpatched-vte=true'
     sources:
     - type: dir
       path: .

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
-option ('ubuntu-bionic-patched-vte', type : 'boolean', value : true)
-option ('patched-vte', type : 'boolean', value : false)
+option ('ubuntu-bionic-patched-vte', type : 'boolean', value : false)
+option ('patched-vte', type : 'boolean', value : true)
 option ('with-gpg', type : 'boolean', value : true)


### PR DESCRIPTION
Fixes #166

From https://github.com/muriloventuroso/easyssh/issues/166#issuecomment-1312746195:

> Ready to execute `cd build; ninja test`. Pity, the result is a failure; [ninja_test.txt](https://github.com/muriloventuroso/easyssh/files/9997432/ninja_test.txt).

These values are for older version of elementary OS; we should update these values for more recent version of Vte