### PR TITLE
ConnectionEditor: Fix sensitivity of add/remove tunnel buttons

### DIFF
--- a/src/Widgets/ConnectionEditor.vala
+++ b/src/Widgets/ConnectionEditor.vala
@@ -383,9 +383,14 @@ namespace EasySSH {
             var button_remove_tunnel = new Gtk.Button.with_label (_("Remove"));
             button_remove_tunnel.clicked.connect(() => {
                 var row = list_tunnels.get_selected_row();
+                if (row == null) {
+                    return;
+                }
+
                 var index_row = row.get_index();
                 array_tunnels.remove_at(index_row);
                 list_tunnels.remove(row);
+                button_remove_tunnel.sensitive = (array_tunnels.size != 0);
             });
             grid_tunnels.attach(scroll_tunnels, 0, 0, 1, 4);
             grid_tunnels.attach_next_to(button_remove_tunnel, scroll_tunnels, Gtk.PositionType.RIGHT, 1, 1);
@@ -429,6 +434,17 @@ namespace EasySSH {
                 source_port_entry.text = "";
                 destination_entry.text = "";
                 list_tunnels.show_all ();
+                button_remove_tunnel.sensitive = (array_tunnels.size != 0);
+            });
+            source_port_entry.notify["text"].connect (() => {
+                button_add_tunnel.sensitive = (
+                        (source_port_entry.text_length > 0) && (destination_entry.text_length > 0)
+                );
+            });
+            destination_entry.notify["text"].connect (() => {
+                button_add_tunnel.sensitive = (
+                        (source_port_entry.text_length > 0) && (destination_entry.text_length > 0)
+                );
             });
 
             add_tunnel_grid.attach (button_add_tunnel, 6, 0, 1, 1);
@@ -449,6 +465,7 @@ namespace EasySSH {
 
             grid.attach (buttons, 0, 18, 1, 1);
             update_save_button();
+            button_remove_tunnel.sensitive = (array_tunnels.size != 0);
             show_all ();
             if(data_host == null) {
                 identityfile_chooser.hide();

--- a/src/Widgets/ConnectionEditor.vala
+++ b/src/Widgets/ConnectionEditor.vala
@@ -380,7 +380,9 @@ namespace EasySSH {
             list_tunnels.set_hexpand (true);
             var grid_tunnels = new Gtk.Grid();
             grid_tunnels.get_style_context ().add_class("list-tunnels");
-            var button_remove_tunnel = new Gtk.Button.with_label (_("Remove"));
+            var button_remove_tunnel = new Gtk.Button.with_label (_("Remove")) {
+                sensitive = false
+            };
             button_remove_tunnel.clicked.connect(() => {
                 var row = list_tunnels.get_selected_row();
                 if (row == null) {
@@ -390,7 +392,6 @@ namespace EasySSH {
                 var index_row = row.get_index();
                 array_tunnels.remove_at(index_row);
                 list_tunnels.remove(row);
-                button_remove_tunnel.sensitive = (array_tunnels.size != 0);
             });
             grid_tunnels.attach(scroll_tunnels, 0, 0, 1, 4);
             grid_tunnels.attach_next_to(button_remove_tunnel, scroll_tunnels, Gtk.PositionType.RIGHT, 1, 1);
@@ -434,7 +435,6 @@ namespace EasySSH {
                 source_port_entry.text = "";
                 destination_entry.text = "";
                 list_tunnels.show_all ();
-                button_remove_tunnel.sensitive = (array_tunnels.size != 0);
             });
             source_port_entry.notify["text"].connect (() => {
                 button_add_tunnel.sensitive = (
@@ -445,6 +445,9 @@ namespace EasySSH {
                 button_add_tunnel.sensitive = (
                         (source_port_entry.text_length > 0) && (destination_entry.text_length > 0)
                 );
+            });
+            list_tunnels.row_selected.connect ((row) => {
+                button_remove_tunnel.sensitive = (row != null);
             });
 
             add_tunnel_grid.attach (button_add_tunnel, 6, 0, 1, 1);
@@ -465,7 +468,6 @@ namespace EasySSH {
 
             grid.attach (buttons, 0, 18, 1, 1);
             update_save_button();
-            button_remove_tunnel.sensitive = (array_tunnels.size != 0);
             show_all ();
             if(data_host == null) {
                 identityfile_chooser.hide();


### PR DESCRIPTION
Fixes #169
Fixes #170

- "Remove" button now gets sensitive only when some element in the forwarding list is selected
- Prevent from proceeding when no element in the forwarding list is selected
- Set the "Add Tunnel" button sensitive only when both of the two entries "Source Path:" and "Destination:" has some texts and set it to insensitive otherwise

![スクリーンショット 2022-11-27 18 45 03](https://user-images.githubusercontent.com/26003928/204128829-e57bf6c9-cef2-4858-9404-0b533b644b6d.png)
