### PR TITLE
SourceListView: Fix segfault when adding account

### DIFF
--- a/src/Views/SourceListView.vala
+++ b/src/Views/SourceListView.vala
@@ -1083,7 +1083,7 @@ namespace EasySSH {
                 if(accounts[i] == null) {
                     continue;
                 }
-                var s_account = new Host();
+                var s_account = new Account();
                 s_account.name = accounts[i].name;
                 s_account.username = accounts[i].username;
                 s_account.password = accounts[i].password;


### PR DESCRIPTION
Fixes the segfault with the following error messages when adding a new account:

```
(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.102: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.102: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.103: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.103: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.103: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.103: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.103: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.103: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.103: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.104: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.104: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.104: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.104: Unsupported type `gpointer'

(com.github.muriloventuroso.easyssh:2): Json-WARNING **: 20:47:13.104: Unsupported type `gpointer'
```