### PR TITLE
Fix runtime warnings

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -489,7 +489,10 @@ namespace EasySSH {
                 action_accelerators.remove_all(ACTION_SEARCH_NEXT);
                 action_accelerators.remove_all(ACTION_SEARCH_PREVIOUS);
                 search_toolbar.clear ();
-                current_terminal.grab_focus ();
+
+                if (current_terminal != null) {
+                    current_terminal.grab_focus ();
+                }
             }
 
             string [] next_accels = new string [] {};

--- a/src/Views/SourceListView.vala
+++ b/src/Views/SourceListView.vala
@@ -520,6 +520,7 @@ namespace EasySSH {
                 var t = get_term_widget (new_tab);
                 window.current_terminal = t;
                 var box = (TerminalBox)new_tab.page;
+                box.tab = new_tab;
                 box.set_selected();
                 new_tab.icon = null;
                 var all_read = true;

--- a/src/Views/SourceListView.vala
+++ b/src/Views/SourceListView.vala
@@ -226,7 +226,6 @@ namespace EasySSH {
                         window.current_terminal = (TerminalWidget)box.term;
                         window.current_terminal.grab_focus();
                         box.set_selected();
-                        box.remove_badge ();
                     }
                 }
                 var all_read = true;
@@ -508,7 +507,6 @@ namespace EasySSH {
                 var box = (TerminalBox)tab.page;
                 window.current_terminal = t;
                 box.set_selected();
-                box.remove_badge ();
             }
         }
         private void on_tab_added (Granite.Widgets.Tab tab) {
@@ -523,8 +521,6 @@ namespace EasySSH {
                 window.current_terminal = t;
                 var box = (TerminalBox)new_tab.page;
                 box.set_selected();
-                box.remove_badge ();
-                box.dataHost.item.icon = null;
                 new_tab.icon = null;
                 var all_read = true;
                 foreach (var g_tab in box.dataHost.notebook.tabs) {
@@ -541,7 +537,6 @@ namespace EasySSH {
             if(Type.from_instance(new_tab.page).name() == "EasySSHTerminalBox") {
                 var box = (TerminalBox)new_tab.page;
                 box.remove_badge ();
-                box.dataHost.item.icon = null;
                 var all_read = true;
                 foreach (var g_tab in box.dataHost.notebook.tabs) {
                     if(g_tab.icon != null) {

--- a/src/Widgets/AccountEditor.vala
+++ b/src/Widgets/AccountEditor.vala
@@ -94,6 +94,7 @@ namespace EasySSH {
             buttons.pack_end(save_button, false, false, 0);
 
             
+            label = new Gtk.Label(null);
             label.get_style_context ().add_class("h2");
             grid.add (label);
             grid.attach (new Granite.HeaderLabel (_("Name:")), 0, 1, 1, 1);
@@ -126,12 +127,12 @@ namespace EasySSH {
             update_save_button();
             show_all ();
             if(data_account == null) {
-                label = new Gtk.Label(_("Add Account"));
+                label.label = _("Add Account");
             } else {
                 if(duplicate == false){
-                    label = new Gtk.Label(_("Edit Account"));
+                    label.label = _("Edit Account");
                 }else{
-                    label = new Gtk.Label(_("Duplicate Account"));
+                    label.label = _("Duplicate Account");
                 }
                 name_entry.text = data_account.name;
                 name_entry.is_valid = check_name();

--- a/src/Widgets/ConnectionEditor.vala
+++ b/src/Widgets/ConnectionEditor.vala
@@ -222,12 +222,11 @@ namespace EasySSH {
                 }
 
             });
-            grid.attach (change_password, 0, 14, 1, 1);
             if(Application.settings.get_boolean ("sync-ssh-config")){
                 ssh_config_entry.set_vexpand(true);
                 ssh_config_entry.buffer.text = sourcelistview.get_host_ssh_config (data_host.name);
-                grid.attach (new Granite.HeaderLabel (_("SSH Config:")), 0, 15, 2, 1);
-                grid.attach (ssh_config_scroll, 0, 16, 1, 1);
+                grid.attach (new Granite.HeaderLabel (_("SSH Config:")), 0, 13, 2, 1);
+                grid.attach (ssh_config_scroll, 0, 14, 1, 1);
 
                 host_entry.key_release_event.connect (() => {
                     var text_config = ssh_config_entry.buffer.text.split("\n");
@@ -463,10 +462,10 @@ namespace EasySSH {
             box_advanced.pack_start(main_stackswitcher, false, false, 0);
             box_advanced.pack_start(main_stack, false, false, 0);
             revealer.add(box_advanced);
-            grid.attach (revealer, 0, 17, 1, 1);
+            grid.attach (revealer, 0, 15, 1, 1);
             advanced_button.bind_property ("active", revealer, "reveal-child");
 
-            grid.attach (buttons, 0, 18, 1, 1);
+            grid.attach (buttons, 0, 16, 1, 1);
             update_save_button();
             show_all ();
             if(data_host == null) {


### PR DESCRIPTION
Fixes the following warnings:

- On pressing "Add Connection" button in the Hosts welcome screen:

```
(com.github.muriloventuroso.easyssh:2): Gtk-CRITICAL **: 09:01:13.067: gtk_grid_attach: assertion '_gtk_widget_get_parent (child) == NULL' failed
```

- On pressing "Add Accounts" button in the Accounts welcome screen:

```
(com.github.muriloventuroso.easyssh:2): Gtk-CRITICAL **: 09:02:20.747: gtk_widget_get_style_context: assertion 'GTK_IS_WIDGET (widget)' failed

(com.github.muriloventuroso.easyssh:2): Gtk-CRITICAL **: 09:02:20.747: gtk_style_context_add_class: assertion 'GTK_IS_STYLE_CONTEXT (context)' failed

(com.github.muriloventuroso.easyssh:2): Gtk-CRITICAL **: 09:02:20.747: gtk_container_add: assertion 'GTK_IS_WIDGET (widget)' failed
```

- On pressing the search icon in the headerbar when you have no terminal open (e.g. in the welcome screen):

```
(com.github.muriloventuroso.easyssh:2): Gtk-CRITICAL **: 09:03:34.260: gtk_widget_grab_focus: assertion 'GTK_IS_WIDGET (widget)' failed
```

- On removing the last remaining localhost tab:

```
** (com.github.muriloventuroso.easyssh:2): CRITICAL **: 09:06:16.337: granite_widgets_tab_set_icon: assertion 'self != NULL' failed
```